### PR TITLE
perf: improve deserialization of DateTime by 3x 

### DIFF
--- a/dlhn/benches/date_time.rs
+++ b/dlhn/benches/date_time.rs
@@ -1,4 +1,4 @@
-use dlhn::Serializer;
+use dlhn::{DateTime, Deserializer, Serializer};
 use iai::main;
 use serde::{Deserialize, Serialize};
 use time::OffsetDateTime;
@@ -19,4 +19,26 @@ fn serialize() -> Vec<u8> {
     buf
 }
 
-main!(serialize,);
+#[derive(Debug, PartialEq, Serialize, Deserialize)]
+struct Test2 {
+    date_time: DateTime,
+}
+
+fn serialize2() -> Vec<u8> {
+    let mut buf = Vec::new();
+    let mut serializer = Serializer::new(&mut buf);
+    let body = Test2 {
+        date_time: DateTime::from(OffsetDateTime::UNIX_EPOCH),
+    };
+    body.serialize(&mut serializer).unwrap();
+    buf
+}
+
+fn deserialize2() -> DateTime {
+    let buf = serialize2();
+    let mut reader = buf.as_slice();
+    let mut deserializer = Deserializer::new(&mut reader);
+    DateTime::deserialize(&mut deserializer).unwrap()
+}
+
+main!(serialize, serialize2, deserialize2);


### PR DESCRIPTION
## Before
```
deserialize2
  Instructions:                3074
  L1 Accesses:                 4341
  L2 Accesses:                   14
  RAM Accesses:                  80
  Estimated Cycles:            7211
```
## After
```
deserialize2
  Instructions:                 643
  L1 Accesses:                  862
  L2 Accesses:                    7
  RAM Accesses:                  48
  Estimated Cycles:            2577
```